### PR TITLE
Load data entries and sources into cache

### DIFF
--- a/machine/core/CacheManager.php
+++ b/machine/core/CacheManager.php
@@ -85,7 +85,9 @@
         self::getTable('session_states', $refresh);
         self::getTable('statuses', $refresh);
         self::getTable('data_source_types', $refresh);
+        self::getTable('data_sources', $refresh);
         self::getTable('data_entry_types', $refresh);
+        self::getTable('data_entries', $refresh);
         self::getTable('connection_types', $refresh);
         self::getTable('connection_node_types', $refresh);
         self::getTable('request_authorization', $refresh);


### PR DESCRIPTION
When the system compiles process connection when running different tasks, it uses the data entries and sources to understand where data is coming from and it's destination. Pre-loading the data into the cache is much faster than quering the data from the database, this basically improves performance and is possible since the data_entries and data_sources tables are small tables containing only metadata about the system.